### PR TITLE
Add field operators override

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ type AdvProp = {
     type: PropType
     label?: string
     choices?: Choice[]
+    operators: FieldFilterOperator[]
 }
 
 type RelationProp = {
@@ -85,6 +86,10 @@ type RelationProp = {
                     "text": "Female",
                     "value": "female"
                 }
+            ],
+            "operators": [ // Override default operators for this type (@see @directus/utils/getFilterOperatorsForType) 
+                "eq",
+                "neq"
             ]
         }
     }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ type AdvProp = {
     type: PropType
     label?: string
     choices?: Choice[]
-    operators: FieldFilterOperator[]
+    operators?: FieldFilterOperator[]
 }
 
 type RelationProp = {
@@ -87,7 +87,8 @@ type RelationProp = {
                     "value": "female"
                 }
             ],
-            "operators": [ // Override default operators for this type (@see @directus/utils/getFilterOperatorsForType) 
+             // (optional) Override default operators for this type (@see @directus/utils/getFilterOperatorsForType) 
+            "operators": [
                 "eq",
                 "neq"
             ]

--- a/src/components/nodes.vue
+++ b/src/components/nodes.vue
@@ -278,8 +278,8 @@ function replaceNode(index, newFilter) {
 function getCompareOptions(name) {
 	const fieldInfo = get(props.tree, name);
 	if (!fieldInfo) return [];
-
-	return getFilterOperatorsForType(fieldInfo.type || 'string').map(type => ({
+        const operators = (fieldInfo.operators && fieldInfo.operators.length > 0) ? fieldInfo.operators : getFilterOperatorsForType(fieldInfo.type || 'string');
+	return operators.map(type => ({
 		text: t(`operators.${type}`),
 		value: `_${type}`,
 	}));

--- a/src/components/nodes.vue
+++ b/src/components/nodes.vue
@@ -278,7 +278,7 @@ function replaceNode(index, newFilter) {
 function getCompareOptions(name) {
 	const fieldInfo = get(props.tree, name);
 	if (!fieldInfo) return [];
-        const operators = (fieldInfo.operators && fieldInfo.operators.length > 0) ? fieldInfo.operators : getFilterOperatorsForType(fieldInfo.type || 'string');
+        const operators = (Array.isArray(fieldInfo.operators) && fieldInfo.operators.length > 0) ? fieldInfo.operators : getFilterOperatorsForType(fieldInfo.type || 'string');
 	return operators.map(type => ({
 		text: t(`operators.${type}`),
 		value: `_${type}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ const config: InterfaceConfig = {
 							name: {
 								name: 'Full name',
 								type: 'string',
+                                                                operators: ['eq', 'neq'],
 							},
 							age: 'integer',
 							gender: {


### PR DESCRIPTION
# Description

By default, operators are determined based on the field type using the `getFilterOperatorsForType` function ( https://github.com/directus/directus/blob/78546678d0469012628a9ee71207ef4e9e608a27/packages/utils/shared/get-filter-operators-for-type.ts#L7)

For example, if the field type is  `string`, operators available in Directus interface will be : 
- `contains`
- `ncontains`
- `icontains`
- `starts_with`
- `nstarts_with`
- `istarts_with`
- `nistarts_with`
- `ends_with`
- `nends_with`
- `iends_with`
- `niends_with`
- `eq`
- `neq`
- `empty`
- `nempty`
- `null`
- `nnull`
- `in`
- `nin`

With the introduction of the new `operators` field property, it is now possible to specify a subset of operators for a given field. For example, you can set the operators to only include :
- `eq`
- `neq`

This feature is useful when the business logic handling the rule does not support all default operators.

# Changes Made

Added a new operators property to the `AdvProp` type.
Updated the logic to prioritize operators specified in the `operators` property over those determined by the `getFilterOperatorsForType` function.


# Screenshots

## Field edition
![image](https://github.com/u12206050/directus-extension-filters-interface/assets/781241/c7dc27e8-bf82-45d6-95d3-052eb21dea1f)

## Field interface
![image](https://github.com/u12206050/directus-extension-filters-interface/assets/781241/eb8bc06d-659d-4268-9741-ee0876e141fc)


# Testing

Manually tested on Directus 10.10.7

- [x] If field has no `operators` property, all operators available for this type are shown in interface 
- [x] If field has empty `operators` property, all operators available for this type are shown in interface 
- [x] If field has `operators` property, only those operators are shown in interface 